### PR TITLE
Add RPC encryption CA reg key

### DIFF
--- a/src/CommonLib/OutputTypes/CARegistryData.cs
+++ b/src/CommonLib/OutputTypes/CARegistryData.cs
@@ -8,5 +8,6 @@ namespace SharpHoundCommonLib.OutputTypes
         public EnrollmentAgentRegistryAPIResult EnrollmentAgentRestrictions { get; set; }
         public BoolRegistryAPIResult IsUserSpecifiesSanEnabled { get; set; }
         public BoolRegistryAPIResult RoleSeparationEnabled { get; set; }
+        public BoolRegistryAPIResult RPCEncryptionEnforced { get; set; }
     }
 }

--- a/src/CommonLib/Processors/CertAbuseProcessor.cs
+++ b/src/CommonLib/Processors/CertAbuseProcessor.cs
@@ -277,6 +277,33 @@ namespace SharpHoundCommonLib.Processors
             return ret;
         }
 
+        [ExcludeFromCodeCoverage]
+        public BoolRegistryAPIResult RPCEncryptionEnforced(string target, string caName)
+        {
+            var ret = new BoolRegistryAPIResult();
+            var subKey =
+                $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}";
+            const string subValue = "InterfaceFlags";
+            var data = Helpers.GetRegistryKeyData(target, subKey, subValue, _log);
+
+            ret.Collected = data.Collected;
+            if (!data.Collected)
+            {
+                ret.FailureReason = data.FailureReason;
+                return ret;
+            }
+
+            if (data.Value == null)
+            {
+                return ret;
+            }
+
+            var interfaceFlags = (int)data.Value;
+            ret.Value = (interfaceFlags & 0x00000200) == 0x00000200;
+
+            return ret;
+        }
+
         /// <summary>
         /// This function checks a registry setting on the target host for the specified CA to see if role seperation is enabled.
         /// If enabled, you cannot perform any CA actions if you have both ManageCA and ManageCertificates permissions. Only CA admins can modify the setting.


### PR DESCRIPTION
## Description

Collection of additional CA reg key value (RPC encryption enforcement) 

## Motivation and Context

This change is required for ADCS ESC11 coverage.

Corresponding BHCE PR: https://github.com/SpecterOps/BloodHound/pull/1679

Resolves BED-6182

## How Has This Been Tested?

Locally in lab.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to check whether RPC encryption enforcement is enabled for a certification authority on a target host.
  * Added clear success and failure status reporting for RPC encryption checks.

* **Bug Fixes**
  * Improved handling of registry lookup failures by preserving the failure reason and status.
  * Improved detection across supported interface flag values.
  * RPC encryption checks now safely return a disabled result when the configuration value is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->