### PR TITLE
feat: collect msDS-aADObjectID for users and groups - BED-9245

### DIFF
--- a/src/CommonLib/Enums/LDAPProperties.cs
+++ b/src/CommonLib/Enums/LDAPProperties.cs
@@ -32,6 +32,7 @@
         public const string UserPassword = "userpassword";
         public const string SIDHistory = "sidhistory";
         public const string AllowedToActOnBehalfOfOtherIdentity = "msds-allowedtoactonbehalfofotheridentity";
+        public const string AADObjectID = "msds-aadobjectid";
         public const string OperatingSystem = "operatingsystem";
         public const string ServicePack = "operatingsystemservicepack";
         public const string DNSHostName = "dnshostname";

--- a/src/CommonLib/LdapQueries/CommonProperties.cs
+++ b/src/CommonLib/LdapQueries/CommonProperties.cs
@@ -54,7 +54,7 @@
             LDAPProperties.DomainFunctionalLevel, LDAPProperties.ObjectGUID, LDAPProperties.Name,
             LDAPProperties.GroupPolicyOptions, LDAPProperties.AllowedToDelegateTo,
             LDAPProperties.AllowedToActOnBehalfOfOtherIdentity, LDAPProperties.WhenCreated,
-            LDAPProperties.HostServiceAccount, LDAPProperties.UnixUserPassword, LDAPProperties.MsSFU30Password,
+            LDAPProperties.AADObjectID, LDAPProperties.HostServiceAccount, LDAPProperties.UnixUserPassword, LDAPProperties.MsSFU30Password,
             LDAPProperties.UnicodePassword, LDAPProperties.ProfilePath, LDAPProperties.ScriptPath,
             LDAPProperties.ExpirePasswordsOnSmartCardOnlyAccounts, LDAPProperties.MachineAccountQuota, 
             LDAPProperties.SupportedEncryptionTypes, LDAPProperties.DSHeuristics,

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -16,6 +16,7 @@ using SharpHoundCommonLib.OutputTypes;
 
 namespace SharpHoundCommonLib.Processors {
     public class LdapPropertyProcessor {
+        private const string AADObjectIDProperty = "aadobjectid";
         private static readonly HashSet<string> ReservedAttributes = new();
         public delegate Task ComputerStatusDelegate(CSVComputerStatus status);
         public event ComputerStatusDelegate ComputerStatusEvent;
@@ -69,6 +70,13 @@ namespace SharpHoundCommonLib.Processors {
             }
 
             return ret;
+        }
+
+        private static void AddAADObjectIDProperty(Dictionary<string, object> props, IDirectoryObject entry) {
+            if (entry.TryGetProperty(LDAPProperties.AADObjectID, out var aadObjectID) &&
+                !string.IsNullOrWhiteSpace(aadObjectID)) {
+                props[AADObjectIDProperty] = aadObjectID.Trim().ToUpperInvariant();
+            }
         }
 
         /// <summary>
@@ -212,6 +220,7 @@ namespace SharpHoundCommonLib.Processors {
         {
             var groupProperties = new GroupProperties();
             var props = GetCommonProps(entry);
+            AddAADObjectIDProperty(props, entry);
             entry.TryGetLongProperty(LDAPProperties.AdminCount, out var ac);
             props.Add("admincount", ac != 0);
             entry.TryGetLongProperty(LDAPProperties.GroupType, out var groupType);
@@ -249,6 +258,7 @@ namespace SharpHoundCommonLib.Processors {
         public async Task<UserProperties> ReadUserProperties(IDirectoryObject entry, string domain) {
             var userProps = new UserProperties();
             var props = GetCommonProps(entry);
+            AddAADObjectIDProperty(props, entry);
 
             if (entry.TryGetLongProperty(LDAPProperties.UserAccountControl, out var uac)) {
               var uacFlags = (UacFlags)uac;

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -126,6 +126,7 @@ namespace CommonLibTest
                 new Dictionary<string, object>
                 {
                     {"description", "Test"},
+                    {"msds-aadobjectid", "b9b08d75-5bca-4fd4-a75d-7de9fdbe0cd3"},
                     {"admincount", "1"}
                 }, "S-1-5-21-3130019616-2776909439-2417379446-512","");
             var processor = new LdapPropertyProcessor(new MockLdapUtils());
@@ -136,6 +137,9 @@ namespace CommonLibTest
             Assert.Equal("Test", test["description"] as string);
             Assert.Contains("admincount", test.Keys);
             Assert.True((bool)test["admincount"]);
+            Assert.Contains("aadobjectid", test.Keys);
+            Assert.Equal("B9B08D75-5BCA-4FD4-A75D-7DE9FDBE0CD3", test["aadobjectid"] as string);
+            Assert.DoesNotContain("msds-aadobjectid", test.Keys);
         }
 
         [Fact]
@@ -319,6 +323,7 @@ namespace CommonLibTest
                     {"lastlogontimestamp", "132670318095676525"},
                     {"homedirectory", @"\\win10\testdir"},
                     {"mail", "test@testdomain.com"},
+                    {"msds-aadobjectid", "3b6ace22-ae1c-49b9-bb40-66b30c5bc9e5"},
                     {
                         "serviceprincipalname", new[]
                         {
@@ -355,6 +360,9 @@ namespace CommonLibTest
             Assert.Equal(@"\\win10\testdir", props["homedirectory"] as string);
             Assert.Contains("email", keys);
             Assert.Equal("test@testdomain.com", props["email"] as string);
+            Assert.Contains("aadobjectid", keys);
+            Assert.Equal("3B6ACE22-AE1C-49B9-BB40-66B30C5BC9E5", props["aadobjectid"] as string);
+            Assert.DoesNotContain("msds-aadobjectid", keys);
 
             //UAC stuff
             Assert.Contains("sensitive", keys);
@@ -1074,6 +1082,7 @@ namespace CommonLibTest
                     {"name", "NTAUTHCERTIFICATES@DUMPSTER.FIRE"},
                     {"domainsid", "S-1-5-21-2697957641-2271029196-387917394"},
                     {"whencreated", 1683986131},
+                    {"msds-aadobjectid", "b9b08d75-5bca-4fd4-a75d-7de9fdbe0cd3"},
                     {LDAPProperties.DSASignature, "jkr"}
                 }, "", "2F9F3630-F46A-49BF-B186-6629994EBCF9");
 
@@ -1085,6 +1094,7 @@ namespace CommonLibTest
             Assert.DoesNotContain("description", keys);
             Assert.DoesNotContain("whencreated", keys);
             Assert.DoesNotContain("name", keys);
+            Assert.DoesNotContain("msds-aadobjectid", keys);
             Assert.DoesNotContain(LDAPProperties.DSASignature, keys);
 
             Assert.Contains("domainsid", keys);


### PR DESCRIPTION
## Description

Collects `msDS-aADObjectID` for users and groups in Microsoft Entra Domain Services and emits the normalized value as `aadobjectid`.

## Motivation and Context

BloodHound uses `aadobjectid` to correlate Microsoft Entra ID identities with their synchronized Entra DS counterparts.

This PR is part of: [BED-9245](https://specterops.atlassian.net/browse/BED-9245)

## How Has This Been Tested?

- Added unit coverage for user and group collection, normalization, and blank values.
- Ran `dotnet test test/unit/CommonLibTest.csproj`: 430 of 431 tests passed.
- One unrelated timestamp assertion failed locally by one day in `ConvertFileTimeToUnixEpoch_ValidTimestamp_ValidUnixEpoch`.
- Built SharpHound with this SharpHoundCommon revision and confirmed `aadobjectid` in the lab collection for 5 users and 7 groups.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Chore
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist:

- [ ] I have met the contributing prerequisites
- [x] I have ensured that related documentation is up-to-date
- [ ] I have followed proper test practices
  - Added/updated tests to cover these changes.
  - One unrelated existing test failure is documented above.

[BED-9245]: https://specterops.atlassian.net/browse/BED-9245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading Azure AD object IDs from directory records.
  * Object IDs are normalized for consistent use across user and group properties.
  * The original directory-specific attribute is excluded from generic property results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->