### PR TITLE
fix: Make ACLProcessor guid cache singleton and thread-safe - BED-9236

### DIFF
--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -13,16 +13,20 @@ using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.LDAPQueries;
 using SharpHoundCommonLib.OutputTypes;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace SharpHoundCommonLib.Processors {
     public class ACLProcessor {
         private static readonly Dictionary<Label, string> BaseGuids;
-        private readonly ConcurrentDictionary<string, string> _guidMap = new();
+        /// This is a shared cache of GUID mappings for each ILdapUtils instance. It allows multiple ACLProcessor instances to share the same GUID cache for a given ILdapUtils instance.
+        /// This resolves an issue from back when the guid cache was static and shared across all ILdapUtils instances, which was causing issues when domains were being processed in parallel for tests: https://github.com/SpecterOps/SharpHoundCommon/pull/169
+        /// Learn about Conditional Weak Tables https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.conditionalweaktable-2?view=netframework-4.7.2#examples
+        /// But the short version is that this allows us to have a shared cache for each ILdapUtils instance, but when the ILdapUtils instance is garbage collected, the cache will be garbage collected as well.
+        private static readonly ConditionalWeakTable<ILdapUtils, GuidCacheState> SharedGuidCaches = new();
         private readonly ILogger _log;
         private readonly ILdapUtils _utils;
-        private readonly ConcurrentHashSet _builtDomainCaches = new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, string[]> _exchangeTrusteeSidCache = new(StringComparer.OrdinalIgnoreCase);
-        private readonly object _lock = new();
         // These Exchange principals commonly carry product-added deny ACEs that we intentionally suppress.
         private static readonly HashSet<string> ExchangeTrusteeNames = new(StringComparer.OrdinalIgnoreCase) {
             "Exchange Windows Permissions",
@@ -30,6 +34,17 @@ namespace SharpHoundCommonLib.Processors {
             "Exchange Servers",
             "Organization Management"
         };
+        private readonly GuidCacheState _guidCache;
+
+        private sealed class GuidCacheState {
+            // This is a mapping of GUIDs to their corresponding names for LDAP rights.
+            // The collection represents the response from the LDAP query Task kept in BuildTasks.
+            public readonly ConcurrentDictionary<string, string> GuidMap = new();
+            // This is a mapping of domains to their corresponding build tasks for the GUID cache.
+            // The Lazy<Task> ensures that the build task is only executed once per domain, even if multiple threads attempt to build the cache for the same domain simultaneously.
+            public readonly ConcurrentDictionary<string, Lazy<Task>> BuildTasks =
+                new(StringComparer.OrdinalIgnoreCase);
+        }
 
         static ACLProcessor() {
             //Create a dictionary with the base GUIDs of each object type
@@ -54,6 +69,7 @@ namespace SharpHoundCommonLib.Processors {
         public ACLProcessor(ILdapUtils utils, ILogger log = null)
         {
             _utils = utils;
+            _guidCache = SharedGuidCaches.GetValue(utils, _ => new GuidCacheState());
             _log = log ?? Logging.LogProvider.CreateLogger("ACLProc");
         }
 
@@ -120,14 +136,14 @@ namespace SharpHoundCommonLib.Processors {
         ///     LAPS
         /// </summary>
         private async Task BuildGuidCache(string domain) {
-            lock (_lock) {
-                if (_builtDomainCaches.Contains(domain)) {
-                    return;
-                }
+            var buildTask = _guidCache.BuildTasks.GetOrAdd(domain,
+                // The ExecutionAndPublication mode ensures that only one thread can execute the factory method at a time, and all other threads will wait for the result of that execution. This prevents multiple threads from building the cache simultaneously for the same domain.
+                _ => new Lazy<Task>(() => BuildGuidCacheCore(domain), LazyThreadSafetyMode.ExecutionAndPublication));
 
-                _builtDomainCaches.Add(domain);
-            }
+            await buildTask.Value;
+        }
 
+        private async Task BuildGuidCacheCore(string domain) {
             _log.LogInformation("Building GUID Cache for {Domain}", domain);
             await foreach (var result in _utils.PagedQuery(new LdapQueryParameters {
                 DomainName = domain,
@@ -155,7 +171,7 @@ namespace SharpHoundCommonLib.Processors {
 
                     if (name is LDAPProperties.LAPSPlaintextPassword or LDAPProperties.LAPSEncryptedPassword or LDAPProperties.LegacyLAPSPassword) {
                         _log.LogInformation("Found GUID for ACL Right {Name}: {Guid} in domain {Domain}", name, guid, domain);
-                        _guidMap.TryAdd(guid, name);
+                        _guidCache.GuidMap.TryAdd(guid, name);
                     }
                 } else {
                     _log.LogDebug("Error while building GUID cache for {Domain}: {Message}", domain, result.Error);
@@ -770,7 +786,7 @@ namespace SharpHoundCommonLib.Processors {
                                     IsPermissionForOwnerRightsSid = isPermissionForOwnerRightsSid,
                                     IsInheritedPermissionForOwnerRightsSid = isInheritedPermissionForOwnerRightsSid,
                                 };
-                            else if (_guidMap.TryGetValue(aceType, out var lapsAttribute)) {
+                            else if (_guidCache.GuidMap.TryGetValue(aceType, out var lapsAttribute)) {
                                 // Compare the retrieved attribute name against LDAPProperties values
                                 if (lapsAttribute == LDAPProperties.LegacyLAPSPassword ||
                                     lapsAttribute == LDAPProperties.LAPSPlaintextPassword ||

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -13,17 +13,43 @@ using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.LDAPQueries;
 using SharpHoundCommonLib.OutputTypes;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace SharpHoundCommonLib.Processors {
+    /// <summary>
+    ///     Owns state shared by processor instances and gives that state an explicit lifetime.
+    /// </summary>
+    public sealed class ACLProcessorContext : IDisposable {
+        private readonly ACLProcessor.GuidCache _aclGuidCache = new();
+        private int _disposed;
+
+        /// <summary>
+        ///     Creates an <see cref="ACLProcessor"/> that shares its GUID cache with other
+        ///     ACL processors created by this context.
+        /// </summary>
+        public ACLProcessor CreateACLProcessor(ILdapUtils utils, ILogger log = null) {
+            if (Volatile.Read(ref _disposed) != 0) {
+                throw new ObjectDisposedException(nameof(ACLProcessorContext));
+            }
+
+            return new ACLProcessor(utils, _aclGuidCache, log);
+        }
+
+        /// <summary>
+        ///     Clears the shared processor state. Processors created by this context must not
+        ///     be used after the context is disposed.
+        /// </summary>
+        public void Dispose() {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) {
+                return;
+            }
+
+            _aclGuidCache.Dispose();
+        }
+    }
+
     public class ACLProcessor {
         private static readonly Dictionary<Label, string> BaseGuids;
-        /// This is a shared cache of GUID mappings for each ILdapUtils instance. It allows multiple ACLProcessor instances to share the same GUID cache for a given ILdapUtils instance.
-        /// This resolves an issue from back when the guid cache was static and shared across all ILdapUtils instances, which was causing issues when domains were being processed in parallel for tests: https://github.com/SpecterOps/SharpHoundCommon/pull/169
-        /// Learn about Conditional Weak Tables https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.conditionalweaktable-2?view=netframework-4.7.2#examples
-        /// But the short version is that this allows us to have a shared cache for each ILdapUtils instance, but when the ILdapUtils instance is garbage collected, the cache will be garbage collected as well.
-        private static readonly ConditionalWeakTable<ILdapUtils, GuidCacheState> SharedGuidCaches = new();
         private readonly ILogger _log;
         private readonly ILdapUtils _utils;
         private readonly ConcurrentDictionary<string, string[]> _exchangeTrusteeSidCache = new(StringComparer.OrdinalIgnoreCase);
@@ -34,16 +60,43 @@ namespace SharpHoundCommonLib.Processors {
             "Exchange Servers",
             "Organization Management"
         };
-        private readonly GuidCacheState _guidCache;
+        private readonly GuidCache _guidCache;
 
-        private sealed class GuidCacheState {
-            // This is a mapping of GUIDs to their corresponding names for LDAP rights.
-            // The collection represents the response from the LDAP query Task kept in BuildTasks.
-            public readonly ConcurrentDictionary<string, string> GuidMap = new();
-            // This is a mapping of domains to their corresponding build tasks for the GUID cache.
-            // The Lazy<Task> ensures that the build task is only executed once per domain, even if multiple threads attempt to build the cache for the same domain simultaneously.
-            public readonly ConcurrentDictionary<string, Lazy<Task>> BuildTasks =
+        internal sealed class GuidCache : IDisposable {
+            private readonly ConcurrentDictionary<string, string> _guidMap = new();
+            private readonly ConcurrentDictionary<string, Lazy<Task>> _buildTasks =
                 new(StringComparer.OrdinalIgnoreCase);
+            private int _disposed;
+
+            public Lazy<Task> GetOrAddBuildTask(string domain, Func<Lazy<Task>> buildTaskFactory) {
+                ThrowIfDisposed();
+                return _buildTasks.GetOrAdd(domain, _ => buildTaskFactory());
+            }
+
+            public void AddGuid(string guid, string name) {
+                ThrowIfDisposed();
+                _guidMap.TryAdd(guid, name);
+            }
+
+            public bool TryGetGuid(string guid, out string name) {
+                ThrowIfDisposed();
+                return _guidMap.TryGetValue(guid, out name);
+            }
+
+            public void Dispose() {
+                if (Interlocked.Exchange(ref _disposed, 1) != 0) {
+                    return;
+                }
+
+                _buildTasks.Clear();
+                _guidMap.Clear();
+            }
+
+            private void ThrowIfDisposed() {
+                if (Volatile.Read(ref _disposed) != 0) {
+                    throw new ObjectDisposedException(nameof(ACLProcessorContext));
+                }
+            }
         }
 
         static ACLProcessor() {
@@ -66,10 +119,12 @@ namespace SharpHoundCommonLib.Processors {
             };
         }
 
-        public ACLProcessor(ILdapUtils utils, ILogger log = null)
-        {
+        public ACLProcessor(ILdapUtils utils, ILogger log = null) : this(utils, new GuidCache(), log) {
+        }
+
+        internal ACLProcessor(ILdapUtils utils, GuidCache guidCache, ILogger log = null) {
             _utils = utils;
-            _guidCache = SharedGuidCaches.GetValue(utils, _ => new GuidCacheState());
+            _guidCache = guidCache;
             _log = log ?? Logging.LogProvider.CreateLogger("ACLProc");
         }
 
@@ -136,9 +191,9 @@ namespace SharpHoundCommonLib.Processors {
         ///     LAPS
         /// </summary>
         private async Task BuildGuidCache(string domain) {
-            var buildTask = _guidCache.BuildTasks.GetOrAdd(domain,
+            var buildTask = _guidCache.GetOrAddBuildTask(domain,
                 // The ExecutionAndPublication mode ensures that only one thread can execute the factory method at a time, and all other threads will wait for the result of that execution. This prevents multiple threads from building the cache simultaneously for the same domain.
-                _ => new Lazy<Task>(() => BuildGuidCacheCore(domain), LazyThreadSafetyMode.ExecutionAndPublication));
+                () => new Lazy<Task>(() => BuildGuidCacheCore(domain), LazyThreadSafetyMode.ExecutionAndPublication));
 
             await buildTask.Value;
         }
@@ -171,7 +226,7 @@ namespace SharpHoundCommonLib.Processors {
 
                     if (name is LDAPProperties.LAPSPlaintextPassword or LDAPProperties.LAPSEncryptedPassword or LDAPProperties.LegacyLAPSPassword) {
                         _log.LogInformation("Found GUID for ACL Right {Name}: {Guid} in domain {Domain}", name, guid, domain);
-                        _guidCache.GuidMap.TryAdd(guid, name);
+                        _guidCache.AddGuid(guid, name);
                     }
                 } else {
                     _log.LogDebug("Error while building GUID cache for {Domain}: {Message}", domain, result.Error);
@@ -786,7 +841,7 @@ namespace SharpHoundCommonLib.Processors {
                                     IsPermissionForOwnerRightsSid = isPermissionForOwnerRightsSid,
                                     IsInheritedPermissionForOwnerRightsSid = isInheritedPermissionForOwnerRightsSid,
                                 };
-                            else if (_guidCache.GuidMap.TryGetValue(aceType, out var lapsAttribute)) {
+                            else if (_guidCache.TryGetGuid(aceType, out var lapsAttribute)) {
                                 // Compare the retrieved attribute name against LDAPProperties values
                                 if (lapsAttribute == LDAPProperties.LegacyLAPSPassword ||
                                     lapsAttribute == LDAPProperties.LAPSPlaintextPassword ||

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -73,6 +73,14 @@ namespace SharpHoundCommonLib.Processors {
                 return _buildTasks.GetOrAdd(domain, _ => buildTaskFactory());
             }
 
+            public bool RemoveBuildTask(string domain, Lazy<Task> buildTask) {
+                // Remove only this instance so a delayed fault cannot remove a newer retry task.
+                // _buildTasks.TryRemove does not guarantee that the value is the same as the one being removed, so we need to cast to ICollection and use Remove instead.
+                // This lets us conditionally remove the task only if it is the same instance as the one we expect.
+                return ((ICollection<KeyValuePair<string, Lazy<Task>>>)_buildTasks)
+                    .Remove(new KeyValuePair<string, Lazy<Task>>(domain, buildTask));
+            }
+
             public void AddGuid(string guid, string name) {
                 ThrowIfDisposed();
                 _guidMap.TryAdd(guid, name);
@@ -195,7 +203,13 @@ namespace SharpHoundCommonLib.Processors {
                 // The ExecutionAndPublication mode ensures that only one thread can execute the factory method at a time, and all other threads will wait for the result of that execution. This prevents multiple threads from building the cache simultaneously for the same domain.
                 () => new Lazy<Task>(() => BuildGuidCacheCore(domain), LazyThreadSafetyMode.ExecutionAndPublication));
 
-            await buildTask.Value;
+            try {
+                await buildTask.Value;
+            }
+            catch {
+                _guidCache.RemoveBuildTask(domain, buildTask);
+                throw;
+            }
         }
 
         private async Task BuildGuidCacheCore(string domain) {

--- a/test/unit/ACLProcessorTest.cs
+++ b/test/unit/ACLProcessorTest.cs
@@ -80,6 +80,34 @@ namespace CommonLibTest {
         }
 
         [Fact]
+        public async Task ProcessorContext_ACLProcessors_RetriesGuidCacheBuildAfterFailure() {
+            var mockLdapUtils = new Mock<ILdapUtils>();
+            var queryAttempts = 0;
+            mockLdapUtils
+                .Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(() => {
+                    if (Interlocked.Increment(ref queryAttempts) == 1) {
+                        throw new InvalidOperationException("Expected test failure");
+                    }
+
+                    return Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable();
+                });
+            var domain = $"{Guid.NewGuid():N}.TEST";
+            using var context = new ACLProcessorContext();
+            var processor = context.CreateACLProcessor(mockLdapUtils.Object);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                processor.ProcessACL(null, domain, Label.Computer, false).ToArrayAsync());
+
+            await processor.ProcessACL(null, domain, Label.Computer, false).ToArrayAsync();
+
+            mockLdapUtils.Verify(
+                x => x.PagedQuery(It.Is<LdapQueryParameters>(parameters => parameters.DomainName == domain),
+                    It.IsAny<CancellationToken>()),
+                Times.Exactly(2));
+        }
+
+        [Fact]
         public async Task ProcessorContext_ACLProcessors_DoNotShareCacheAcrossContexts() {
             var mockLdapUtils = new Mock<ILdapUtils>();
             mockLdapUtils

--- a/test/unit/ACLProcessorTest.cs
+++ b/test/unit/ACLProcessorTest.cs
@@ -59,6 +59,49 @@ namespace CommonLibTest {
         }
 
         [Fact]
+        public async Task ACLProcessor_BuildGuidCache_AcrossInstances_QueriesOncePerDomain() {
+            var mockLdapUtils = new Mock<ILdapUtils>();
+            mockLdapUtils
+                .Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+            var domain = $"{Guid.NewGuid():N}.TEST";
+            var processors = Enumerable.Range(0, 50)
+                .Select(_ => new ACLProcessor(mockLdapUtils.Object))
+                .ToArray();
+
+            await Task.WhenAll(processors.Select(processor =>
+                processor.ProcessACL(null, domain, Label.Computer, false).ToArrayAsync()));
+
+            mockLdapUtils.Verify(
+                x => x.PagedQuery(It.Is<LdapQueryParameters>(parameters => parameters.DomainName == domain),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_BuildGuidCache_AcrossLdapUtils_QueriesOncePerUtility() {
+            var firstLdapUtils = new Mock<ILdapUtils>();
+            var secondLdapUtils = new Mock<ILdapUtils>();
+            foreach (var ldapUtils in new[] { firstLdapUtils, secondLdapUtils }) {
+                ldapUtils
+                    .Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                    .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+            }
+
+            var domain = $"{Guid.NewGuid():N}.TEST";
+            await Task.WhenAll(
+                new ACLProcessor(firstLdapUtils.Object).ProcessACL(null, domain, Label.Computer, false).ToArrayAsync(),
+                new ACLProcessor(secondLdapUtils.Object).ProcessACL(null, domain, Label.Computer, false).ToArrayAsync());
+
+            foreach (var ldapUtils in new[] { firstLdapUtils, secondLdapUtils }) {
+                ldapUtils.Verify(
+                    x => x.PagedQuery(It.Is<LdapQueryParameters>(parameters => parameters.DomainName == domain),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+            }
+        }
+
+        [Fact]
         public void ACLProcessor_IsACLProtected_NullNTSD_ReturnsFalse() {
             var processor = new ACLProcessor(new MockLdapUtils());
             var result = processor.IsACLProtected((byte[])null);

--- a/test/unit/ACLProcessorTest.cs
+++ b/test/unit/ACLProcessorTest.cs
@@ -59,14 +59,15 @@ namespace CommonLibTest {
         }
 
         [Fact]
-        public async Task ACLProcessor_BuildGuidCache_AcrossInstances_QueriesOncePerDomain() {
+        public async Task ProcessorContext_ACLProcessors_QueryOncePerDomain() {
             var mockLdapUtils = new Mock<ILdapUtils>();
             mockLdapUtils
                 .Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
             var domain = $"{Guid.NewGuid():N}.TEST";
+            using var context = new ACLProcessorContext();
             var processors = Enumerable.Range(0, 50)
-                .Select(_ => new ACLProcessor(mockLdapUtils.Object))
+                .Select(_ => context.CreateACLProcessor(mockLdapUtils.Object))
                 .ToArray();
 
             await Task.WhenAll(processors.Select(processor =>
@@ -79,26 +80,43 @@ namespace CommonLibTest {
         }
 
         [Fact]
-        public async Task ACLProcessor_BuildGuidCache_AcrossLdapUtils_QueriesOncePerUtility() {
-            var firstLdapUtils = new Mock<ILdapUtils>();
-            var secondLdapUtils = new Mock<ILdapUtils>();
-            foreach (var ldapUtils in new[] { firstLdapUtils, secondLdapUtils }) {
-                ldapUtils
-                    .Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
-                    .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
-            }
-
+        public async Task ProcessorContext_ACLProcessors_DoNotShareCacheAcrossContexts() {
+            var mockLdapUtils = new Mock<ILdapUtils>();
+            mockLdapUtils
+                .Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
             var domain = $"{Guid.NewGuid():N}.TEST";
-            await Task.WhenAll(
-                new ACLProcessor(firstLdapUtils.Object).ProcessACL(null, domain, Label.Computer, false).ToArrayAsync(),
-                new ACLProcessor(secondLdapUtils.Object).ProcessACL(null, domain, Label.Computer, false).ToArrayAsync());
+            using var firstContext = new ACLProcessorContext();
+            using var secondContext = new ACLProcessorContext();
 
-            foreach (var ldapUtils in new[] { firstLdapUtils, secondLdapUtils }) {
-                ldapUtils.Verify(
-                    x => x.PagedQuery(It.Is<LdapQueryParameters>(parameters => parameters.DomainName == domain),
-                        It.IsAny<CancellationToken>()),
-                    Times.Once);
-            }
+            await Task.WhenAll(
+                firstContext.CreateACLProcessor(mockLdapUtils.Object)
+                    .ProcessACL(null, domain, Label.Computer, false).ToArrayAsync(),
+                secondContext.CreateACLProcessor(mockLdapUtils.Object)
+                    .ProcessACL(null, domain, Label.Computer, false).ToArrayAsync());
+
+            mockLdapUtils.Verify(
+                x => x.PagedQuery(It.Is<LdapQueryParameters>(parameters => parameters.DomainName == domain),
+                    It.IsAny<CancellationToken>()),
+                Times.Exactly(2));
+        }
+
+        [Fact]
+        public void ProcessorContext_CreateACLProcessor_AfterDispose_Throws() {
+            var context = new ACLProcessorContext();
+            context.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => context.CreateACLProcessor(new MockLdapUtils()));
+        }
+
+        [Fact]
+        public async Task ProcessorContext_ACLProcessor_AfterDispose_Throws() {
+            var context = new ACLProcessorContext();
+            var processor = context.CreateACLProcessor(new MockLdapUtils());
+            context.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+                processor.ProcessACL(null, "TEST.LOCAL", Label.Computer, false).ToArrayAsync());
         }
 
         [Fact]


### PR DESCRIPTION
## Description
ACLProcessor instances are spawned for many workers on a thread, and each of those workers had been building their own instanced guid cache.  The change to instanced caches had been done before to resolve test isolation issues: https://github.com/SpecterOps/SharpHoundCommon/pull/169

This correction is a broader fix to correct `static` shared-resource use and state lifetimes.

## Motivation and Context
https://specterops.atlassian.net/wiki/spaces/BE/pages/2297266214/Solving+Static+Caches+in+SharpHound

This PR addresses: BED-9236

## How Has This Been Tested?
Tested on subsequent scans on GOAD lab.

## Screenshots (if appropriate):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Please make sure you have completed all following checks. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability**
  - Failed GUID-cache builds can now be retried successfully instead of remaining stuck in a failed state.
  - Retry handling protects newer attempts from being removed accidentally.

- **Testing**
  - Added coverage for processor lifecycle management, shared and isolated caches, and recovery after failed cache builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->