### PR TITLE
fix: Null protection on Security Descriptor owner - BED-9499

### DIFF
--- a/src/CommonLib/SecurityDescriptor.cs
+++ b/src/CommonLib/SecurityDescriptor.cs
@@ -109,7 +109,7 @@ namespace SharpHoundCommonLib
         {
             // Blocking External Call -- Possible blocking through locks, and Translate call
             // see https://github.com/dotnet/runtime/blob/9d5a6a9aa463d6d10b0b0ba6d5982cc82f363dc3/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ObjectSecurity.cs#L336
-            return _sd.GetOwner(targetType).Value;
+            return _sd.GetOwner(targetType)?.Value;
         }
     }
 }

--- a/test/unit/SecurityDescriptorTests.cs
+++ b/test/unit/SecurityDescriptorTests.cs
@@ -1,0 +1,21 @@
+using System.DirectoryServices;
+using System.Runtime.Versioning;
+using System.Security.Principal;
+using SharpHoundCommonLib;
+using Xunit;
+
+namespace CommonLibTest;
+
+public class SecurityDescriptorTests
+{
+    [SupportedOSPlatform("windows")]
+    [WindowsOnlyFact]
+    public void GetOwner_SecurityDescriptorWithoutOwner_ReturnsNull()
+    {
+        var descriptor = new ActiveDirectorySecurityDescriptor(new ActiveDirectorySecurity());
+
+        var owner = descriptor.GetOwner(typeof(SecurityIdentifier));
+
+        Assert.Null(owner);
+    }
+}


### PR DESCRIPTION
## Description
Don't throw when Security Descriptor has no owner.

## Motivation and Context

This PR addresses: BED-9499

## How Has This Been Tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*
-->

## Screenshots (if appropriate):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Please make sure you have completed all following checks. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Security descriptor ownership checks now safely return no owner when none is configured, instead of causing an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->